### PR TITLE
Prevents long press during active pan

### DIFF
--- a/Views/Input/TouchpadView.swift
+++ b/Views/Input/TouchpadView.swift
@@ -405,11 +405,10 @@ struct AllGesturesView: UIViewRepresentable {
           return
         }
 
-        // Cancel the pan gesture if it started
+        // Don't activate long press if the user was already panning (moving the cursor).
+        // This prevents a mouse-down being sent when the user drags and then holds still.
         if isPanning {
-          singlePan?.isEnabled = false
-          singlePan?.isEnabled = true
-          isPanning = false
+          return
         }
 
         isLongPressing = true


### PR DESCRIPTION
Addresses an issue where dragging the cursor and then holding still would incorrectly activate a long press gesture, leading to an unintended mouse-down event.

This change ensures that a long press gesture is not registered if the user is already actively panning the cursor. This improves the precision and reliability of touchpad input, preventing erroneous interactions.

**Review Focus**
Please review the conditional logic within the long press gesture handler in `TouchpadView.swift` to confirm that the `isPanning` check correctly prevents the long press activation.

**Breaking Changes**
None. This is a bug fix that prevents unintended behavior and does not alter any existing correct functionality.

**How to Test**
1. Navigate to the touchpad input view.
2. Initiate a pan gesture (drag the cursor around).
3. While maintaining contact with the touchpad, stop moving your finger and hold it still.
4. Verify that a long press event (e.g., a right-click or mouse-down behavior) is *not* triggered.
5. Separately, perform a standard long press (press and hold without initial movement) to ensure that the intended long press functionality remains intact.

Fixes #26